### PR TITLE
Fix Resolve URL Value From Being Use String

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,10 +67,6 @@ module.exports = function(source) {
       });
     } else {
       styl.set(key, value);
-
-      if (key === 'resolve url' && value) {
-        styl.define('url', resolver());
-      }
     }
   });
 

--- a/index.js
+++ b/index.js
@@ -65,6 +65,8 @@ module.exports = function(source) {
       needsArray(value).forEach(function(stylusModule) {
         manualImports.push(stylusModule);
       });
+    } else if (key === 'url') {
+      styl.define('url', stylus.resolver(JSON.parse(value)))
     } else {
       styl.set(key, value);
     }


### PR DESCRIPTION
- Remove the if statement when checking if the key is Resolve URL because
  Stylus is no longer using this command as of version 0.52
- Add a Convert to Object from string argument when using an URL argument.
